### PR TITLE
#5 Fixed broken link to license when browsing on GitHub.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,5 @@ License
 Copyright (c) 2013 - 2019, Thomas Aglassinger
 All rights reserved.
 
-Distributed under the BSD license, see [LICENSE.txt]() for more information.
+Distributed under the BSD license, see [LICENSE.txt](LICENSE.txt) for more
+information.


### PR DESCRIPTION
As this is just a minor fix when browsing the repo online it does not justify a release.