### PR TITLE
#5 Fixed OSError during installation

### DIFF
--- a/ebcdic/README.rst
+++ b/ebcdic/README.rst
@@ -145,12 +145,20 @@ and ``ebcdic/__init__.py`` registers it during ``import ebcdic``, so no
 further steps are needed.
 
 
+
+
 Changes
 -------
+
+Version 1.0.2, 2019-07-31
+
+* Fixed OSError during installation (caused by initial implementation of #5).
+
 
 Version 1.0.1, 2019-07-31
 
 * Moved license information from README to LICENSE (#5).
+
 
 Version 1.0.0, 2019-06-06
 

--- a/ebcdic/ebcdic/__init__.py
+++ b/ebcdic/ebcdic/__init__.py
@@ -41,7 +41,7 @@ __all__ = [
     '__version__',
     '__version_info__'
 ]
-__version_info__ = (1, 0, 1)
+__version_info__ = (1, 0, 2)
 __version__ = '.'.join([str(item) for item in __version_info__])
 
 

--- a/ebcdic/setup.cfg
+++ b/ebcdic/setup.cfg
@@ -2,6 +2,9 @@
 [bdist_wheel]
 universal=1
 
+[metadata]
+license_file = LICENSE.txt
+
 [pycodestyle]
 ignore = E124
 max-line-length = 119

--- a/ebcdic/setup.py
+++ b/ebcdic/setup.py
@@ -28,13 +28,8 @@ from setuptools import setup
 
 import io
 import os
-import shutil
 
 import ebcdic
-
-# HACK: Copy the license from the top project folder to the ebcdic folder
-#  because ``data_files`` does not seem to work with files above the current
-#  folder.
 
 # Read the README text to use as long description.
 _PACKAGE_FOLDER = os.path.dirname(os.path.abspath(__file__))
@@ -42,44 +37,34 @@ readme_path = os.path.join(_PACKAGE_FOLDER, 'README.rst')
 with io.open(readme_path, 'r', encoding='utf-8') as readme_file:
     long_description = readme_file.read()
 
-_LICENSE_NAME = "LICENSE.txt"
-_PROJECT_FOLDER = os.path.dirname(_PACKAGE_FOLDER)
-_LICENSE_PATH = os.path.join(_PROJECT_FOLDER, _LICENSE_NAME)
-_COPIED_LICENSE_PATH = os.path.join(_PACKAGE_FOLDER, _LICENSE_NAME)
-shutil.copy(_LICENSE_PATH, os.path.basename(_LICENSE_PATH))
-
-try:
-    setup(
-        name='ebcdic',
-        version=ebcdic.__version__,
-        description='Additional EBCDIC codecs',
-        long_description=long_description,
-        url='https://pypi.python.org/pypi/ebcdic',
-        author='Thomas Aglassinger',
-        author_email='roskakori@users.sourceforge.net',
-        license='BSD',
-        classifiers=[
-            'Development Status :: 5 - Production/Stable',
-            'Intended Audience :: Developers',
-            'Topic :: Text Processing',
-            'License :: OSI Approved :: BSD License',
-            'Programming Language :: Python :: 2',
-            'Programming Language :: Python :: 2.6',
-            'Programming Language :: Python :: 2.7',
-            'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.1',
-            'Programming Language :: Python :: 3.2',
-            'Programming Language :: Python :: 3.3',
-            'Programming Language :: Python :: 3.4',
-            'Programming Language :: Python :: 3.5',
-            'Programming Language :: Python :: 3.6',
-            'Programming Language :: Python :: 3.7',
-            'Programming Language :: Python :: 3.8',
-        ],
-        keywords='codec text unicode ebcdic',
-        packages=['ebcdic'],
-        test_suite='ebcdic.test.test_ebcdic',
-        data_files=[("", [os.path.basename(_LICENSE_PATH)])],
-    )
-finally:
-    os.remove(_COPIED_LICENSE_PATH)
+setup(
+    name='ebcdic',
+    version=ebcdic.__version__,
+    description='Additional EBCDIC codecs',
+    long_description=long_description,
+    url='https://pypi.python.org/pypi/ebcdic',
+    author='Thomas Aglassinger',
+    author_email='roskakori@users.sourceforge.net',
+    license='BSD',
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'Topic :: Text Processing',
+        'License :: OSI Approved :: BSD License',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.1',
+        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+    ],
+    keywords='codec text unicode ebcdic',
+    packages=['ebcdic'],
+    test_suite='ebcdic.test.test_ebcdic',
+)


### PR DESCRIPTION
...caused by kinky Voodoo attempting to reuse the LICENSE.txt of the main CodecMapper project. Now the ebcdic package has its own LICENSE.txt.